### PR TITLE
Disable processing output by default

### DIFF
--- a/lib/scss-lint.js
+++ b/lib/scss-lint.js
@@ -221,7 +221,9 @@ var SCSSLint = {
    * @return {Boolean}
    */
   lint: function (destDir, filePath, options) {
-    console.log('Processing %s'.input, filePath);
+    if (options.verbose) {
+      console.log('Processing %s'.input, filePath);
+    }
 
     var _this = this,
         len   = options.format.length,


### PR DESCRIPTION
Disabled `Processing` output by default. This behavior is better for integration purposes in order not to waste builder output.

Although, it could be enabled by setting `options.verbose` to `true`
